### PR TITLE
Allowing proper migration application

### DIFF
--- a/docker/backend/dockerfile
+++ b/docker/backend/dockerfile
@@ -23,6 +23,6 @@ RUN apt-get update && apt-get install -y wget gnupg2 \
 COPY . /app
 
 # Command to run when starting the container
-CMD ["uvicorn", "backend_api:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD alembic upgrade head && uvicorn backend_api:app --host 0.0.0.0 --port 8000
 
 ENV CHROME_OPTS="--no-sandbox --disable-dev-shm-usage --headless --disable-gpu"

--- a/docker/db/dockerfile
+++ b/docker/db/dockerfile
@@ -3,4 +3,3 @@ ENV POSTGRES_PASSWORD=mysecretpassword
 ENV POSTGRES_USER=myuser
 ENV POSTGRES_DB=bookmap_db
 EXPOSE 5432
-CMD ["alembic", "upgrade", "head"]

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -2,7 +2,7 @@ from logging.config import fileConfig
 from models import Base
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
-
+import os
 from alembic import context
 
 # this is the Alembic Config object, which provides
@@ -24,6 +24,8 @@ target_metadata = Base.metadata
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
+sqlalchemy_url = os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+config.set_main_option("sqlalchemy.url", sqlalchemy_url)
 
 
 def run_migrations_offline() -> None:


### PR DESCRIPTION
I messed up when doing the containers but didn't realize.
Now, Alembic will read the `DATABASE_URL` env var which comes from docker compose and default to localhost if it's not there. This allows the backend container to safely apply the migrations without much trouble and allows the db container to be just DB and nothing else.
