### PR TITLE
Fix setup

### DIFF
--- a/bookscraper_backend/setup.py
+++ b/bookscraper_backend/setup.py
@@ -34,5 +34,5 @@ def setup_db(uri: str | None = None, password: str | None = None):
     logging.info(f"[Neo4j Setup] Setting up connection string to {uri}")
     db.set_connection(connection_string)
     logging.info("[Neo4j Setup] Connection done!")
-    config.DATABASE_URL = connection_string
+    config.DATABASE_URL = connection_string # Neomodel needs to know the proper connection string internally.
     return db

--- a/bookscraper_backend/setup.py
+++ b/bookscraper_backend/setup.py
@@ -28,7 +28,7 @@ def setup_db(uri: str | None = None, password: str | None = None):
         # So to assemble it with password, we need to do this.
         uri = urlparse(uri).netloc
     if not password:
-        print(NEO4J_PASSWORD)
+        print("Using env variable as password.")
         password = NEO4J_PASSWORD
     connection_string = f"bolt://neo4j:{password}@{uri}"
     logging.info(f"[Neo4j Setup] Setting up connection string to {uri}")

--- a/bookscraper_backend/setup.py
+++ b/bookscraper_backend/setup.py
@@ -1,5 +1,5 @@
 import os
-from neomodel import db
+from neomodel import db, config
 from urllib.parse import urlparse
 import logging
 
@@ -34,4 +34,5 @@ def setup_db(uri: str | None = None, password: str | None = None):
     logging.info(f"[Neo4j Setup] Setting up connection string to {uri}")
     db.set_connection(connection_string)
     logging.info("[Neo4j Setup] Connection done!")
+    config.DATABASE_URL = connection_string
     return db

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ def test_profile_endpoint():
     response = client.post(
         "/process-profile/",
         json={
-            "profile_url": "https://www.goodreads.com/user/show/6681479-lucas-pavanelli"
+            "profile_url": "https://www.goodreads.com/user/show/66818479-lucas-pavanelli"
         },
     )
 


### PR DESCRIPTION
The API test was failing due to credentials not being properly inputted and thus neomodel wouldn't be able to do its job. This solved by modifying setup so that nemodel has its config object updated with the proper URL for the Neo4j DB. 