### PR TITLE
fix: environment variables overriding

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,1 @@
-NEO4J_URI=localhost:7687
+NEO4J_URI=bolt://localhost:7687

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,1 @@
-NEO4J_PASSWORD=password
 NEO4J_URI=localhost:7687

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,2 @@
 NEO4J_PASSWORD=password
-NEO4J_URI=pleeeee
-BULL=SHIT
-WHAT=FUCK
+NEO4J_URI=graph_db:7687

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+NEO4J_PASSWORD=password
+NEO4J_URI=pleeeee
+BULL=SHIT
+WHAT=FUCK

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,2 @@
 NEO4J_PASSWORD=password
-NEO4J_URI=graph_db:7687
+NEO4J_URI=localhost:7687

--- a/bookscraper_backend/backend_api.py
+++ b/bookscraper_backend/backend_api.py
@@ -12,13 +12,17 @@ from bookscraper_backend.setup import setup_db
 from graph_db import create_constraints
 from contextlib import asynccontextmanager
 from logger import logger
+import os
+
 class ProfileRequest(BaseModel):
     profile_url: HttpUrl
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    setup_db(uri = "graph_db:7687") # If I pass the actual docker url, this should be fine, right? 
+    neo4j_uri = os.getenv("NEO4J_URI")
+    neo4j_password = os.getenv("NEO4J_PASSWORD")
+    setup_db(uri=neo4j_uri,password=neo4j_password)
     create_constraints()
     yield
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -443,6 +443,19 @@ ssh = ["paramiko (>=2.4.3)"]
 websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
+name = "dotenv"
+version = "0.9.9"
+description = "Deprecated package"
+optional = false
+python-versions = "*"
+files = [
+    {file = "dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9"},
+]
+
+[package.dependencies]
+python-dotenv = "*"
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
@@ -1514,6 +1527,20 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2024.1"
 description = "World timezone definitions, modern and historical"
@@ -2209,4 +2236,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c844ca8fed3d28dd92e4acb7f3901774dcfb28438671dd9e60d119611cad6988"
+content-hash = "20882b86351a90fe02fa74b202d29a88364e3202c3683b881ac1f1ca6bc286c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ snakeviz = "^2.2.0"
 neomodel = "^5.3.1"
 testcontainers = "^4.7.1"
 geopy = "^2.4.1"
+dotenv = "^0.9.9"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.12.1"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,7 @@
 from fastapi.testclient import TestClient
 from bookscraper_backend.backend_api import app
 from dotenv import load_dotenv
-import os
 import pytest
-
-
-#FIXME: The issue here is that if the app calls the DB url locally, it wont resolve because it references graph_db (its meant to run inside containers)
-
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,13 +6,15 @@ import pytest
 
 
 #FIXME: The issue here is that if the app calls the DB url locally, it wont resolve because it references graph_db (its meant to run inside containers)
-load_dotenv(".env.test", override=True)
+
 
 
 @pytest.fixture(scope="module", autouse=True)
 def client():
+    load_dotenv(".env.test", override=True)
     with TestClient(app) as test_client:
         yield test_client
+    load_dotenv(".env", override=True)
 
 def test_profile_endpoint(client: TestClient) -> None:
     response = client.post(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,18 +1,20 @@
 from fastapi.testclient import TestClient
 from bookscraper_backend.backend_api import app
+from dotenv import load_dotenv
 import os
 import pytest
 
 
 #FIXME: The issue here is that if the app calls the DB url locally, it wont resolve because it references graph_db (its meant to run inside containers)
+load_dotenv(".env.test", override=True)
 
-@pytest.fixture(scope="module")
+
+@pytest.fixture(scope="module", autouse=True)
 def client():
     with TestClient(app) as test_client:
         yield test_client
 
 def test_profile_endpoint(client: TestClient) -> None:
-    os.environ["NEO4J_URI"] = "localhost:7687"
     response = client.post(
             "/process-profile/",
             json={
@@ -29,7 +31,6 @@ def test_profile_endpoint(client: TestClient) -> None:
 
 
 def test_profile_endpoint_bad_url(client: TestClient) -> None:
-    os.environ["NEO4J_URI"] = "localhost:7687"
     response = client.post(
             "/process-profile/",
             json={

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ def client():
     with TestClient(app) as test_client:
         yield test_client
 
-def test_profile_endpoint(client):
+def test_profile_endpoint(client: TestClient) -> None:
     os.environ["NEO4J_URI"] = "localhost:7687"
     response = client.post(
             "/process-profile/",
@@ -28,7 +28,7 @@ def test_profile_endpoint(client):
     assert all(data[country] == 0 for country in data if country != "India")
 
 
-def test_profile_endpoint_bad_url(client):
+def test_profile_endpoint_bad_url(client: TestClient) -> None:
     os.environ["NEO4J_URI"] = "localhost:7687"
     response = client.post(
             "/process-profile/",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,9 @@ import pytest
 
 @pytest.fixture(scope="module", autouse=True)
 def client():
+    # Testing happens (now) locally. So .env.test points to localhost. However, since env vars are used when the app is setup
+    # and they are needed to connect the app to the db...
+    # We need to undo the .env.test, hence what we do here.
     load_dotenv(".env.test", override=True)
     with TestClient(app) as test_client:
         yield test_client

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,12 +25,6 @@ def test_profile_endpoint(client: TestClient) -> None:
         )
 
     assert response.status_code == 200
-    # In this profile, we have just 2 books, one from Orwell (India) and Twain (USA)
-    # For stupid reasons, the USA from Goodreads fails. So we expect india = 1, rest 0.
-    data =  response.json()["data"]
-    assert data["India"] == 1
-    assert all(data[country] == 0 for country in data if country != "India")
-
 
 def test_profile_endpoint_bad_url(client: TestClient) -> None:
     response = client.post(


### PR DESCRIPTION
Using python dotenv, we have a solution to the problem of env variables having to be hammered inside of a test and then making production use impossible.